### PR TITLE
Fix regex bugs with replaced code. Simplified implementation as well.

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,9 @@
+// @ts-check
+
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,7145 @@
+{
+	"name": "image-ocr",
+	"version": "0.3.8",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "image-ocr",
+			"version": "0.3.8",
+			"license": "MIT",
+			"dependencies": {
+				"npx": "^10.2.2"
+			},
+			"devDependencies": {
+				"@eslint/js": "^9.11.1",
+				"@types/node": "^16.11.6",
+				"@typescript-eslint/eslint-plugin": "5.29.0",
+				"@typescript-eslint/parser": "5.29.0",
+				"builtin-modules": "3.3.0",
+				"esbuild": "0.17.3",
+				"eslint": "^8.57.1",
+				"globals": "^15.9.0",
+				"obsidian": "latest",
+				"tslib": "2.4.0",
+				"typescript": "4.7.4",
+				"typescript-eslint": "^8.7.0"
+			}
+		},
+		"node_modules/@codemirror/state": {
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.4.1.tgz",
+			"integrity": "sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@codemirror/view": {
+			"version": "6.33.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.33.0.tgz",
+			"integrity": "sha512-AroaR3BvnjRW8fiZBalAaK+ZzB5usGgI014YKElYZvQdNH5ZIidHlO+cyf/2rWzyBFRkvG6VhiXeAEbC53P2YQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@codemirror/state": "^6.4.0",
+				"style-mod": "^4.1.0",
+				"w3c-keyname": "^2.2.4"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.3.tgz",
+			"integrity": "sha512-1Mlz934GvbgdDmt26rTLmf03cAgLg5HyOgJN+ZGCeP3Q9ynYTNMn2/LQxIl7Uy+o4K6Rfi2OuLsr12JQQR8gNg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.3.tgz",
+			"integrity": "sha512-XvJsYo3dO3Pi4kpalkyMvfQsjxPWHYjoX4MDiB/FUM4YMfWcXa5l4VCwFWVYI1+92yxqjuqrhNg0CZg3gSouyQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.3.tgz",
+			"integrity": "sha512-nuV2CmLS07Gqh5/GrZLuqkU9Bm6H6vcCspM+zjp9TdQlxJtIe+qqEXQChmfc7nWdyr/yz3h45Utk1tUn8Cz5+A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.3.tgz",
+			"integrity": "sha512-01Hxaaat6m0Xp9AXGM8mjFtqqwDjzlMP0eQq9zll9U85ttVALGCGDuEvra5Feu/NbP5AEP1MaopPwzsTcUq1cw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.3.tgz",
+			"integrity": "sha512-Eo2gq0Q/er2muf8Z83X21UFoB7EU6/m3GNKvrhACJkjVThd0uA+8RfKpfNhuMCl1bKRfBzKOk6xaYKQZ4lZqvA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.3.tgz",
+			"integrity": "sha512-CN62ESxaquP61n1ZjQP/jZte8CE09M6kNn3baos2SeUfdVBkWN5n6vGp2iKyb/bm/x4JQzEvJgRHLGd5F5b81w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.3.tgz",
+			"integrity": "sha512-feq+K8TxIznZE+zhdVurF3WNJ/Sa35dQNYbaqM/wsCbWdzXr5lyq+AaTUSER2cUR+SXPnd/EY75EPRjf4s1SLg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.3.tgz",
+			"integrity": "sha512-CLP3EgyNuPcg2cshbwkqYy5bbAgK+VhyfMU7oIYyn+x4Y67xb5C5ylxsNUjRmr8BX+MW3YhVNm6Lq6FKtRTWHQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.3.tgz",
+			"integrity": "sha512-JHeZXD4auLYBnrKn6JYJ0o5nWJI9PhChA/Nt0G4MvLaMrvXuWnY93R3a7PiXeJQphpL1nYsaMcoV2QtuvRnF/g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.3.tgz",
+			"integrity": "sha512-FyXlD2ZjZqTFh0sOQxFDiWG1uQUEOLbEh9gKN/7pFxck5Vw0qjWSDqbn6C10GAa1rXJpwsntHcmLqydY9ST9ZA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.3.tgz",
+			"integrity": "sha512-OrDGMvDBI2g7s04J8dh8/I7eSO+/E7nMDT2Z5IruBfUO/RiigF1OF6xoH33Dn4W/OwAWSUf1s2nXamb28ZklTA==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.3.tgz",
+			"integrity": "sha512-DcnUpXnVCJvmv0TzuLwKBC2nsQHle8EIiAJiJ+PipEVC16wHXaPEKP0EqN8WnBe0TPvMITOUlP2aiL5YMld+CQ==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.3.tgz",
+			"integrity": "sha512-BDYf/l1WVhWE+FHAW3FzZPtVlk9QsrwsxGzABmN4g8bTjmhazsId3h127pliDRRu5674k1Y2RWejbpN46N9ZhQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.3.tgz",
+			"integrity": "sha512-WViAxWYMRIi+prTJTyV1wnqd2mS2cPqJlN85oscVhXdb/ZTFJdrpaqm/uDsZPGKHtbg5TuRX/ymKdOSk41YZow==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.3.tgz",
+			"integrity": "sha512-Iw8lkNHUC4oGP1O/KhumcVy77u2s6+KUjieUqzEU3XuWJqZ+AY7uVMrrCbAiwWTkpQHkr00BuXH5RpC6Sb/7Ug==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.3.tgz",
+			"integrity": "sha512-0AGkWQMzeoeAtXQRNB3s4J1/T2XbigM2/Mn2yU1tQSmQRmHIZdkGbVq2A3aDdNslPyhb9/lH0S5GMTZ4xsjBqg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.3.tgz",
+			"integrity": "sha512-4+rR/WHOxIVh53UIQIICryjdoKdHsFZFD4zLSonJ9RRw7bhKzVyXbnRPsWSfwybYqw9sB7ots/SYyufL1mBpEg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.3.tgz",
+			"integrity": "sha512-cVpWnkx9IYg99EjGxa5Gc0XmqumtAwK3aoz7O4Dii2vko+qXbkHoujWA68cqXjhh6TsLaQelfDO4MVnyr+ODeA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.3.tgz",
+			"integrity": "sha512-RxmhKLbTCDAY2xOfrww6ieIZkZF+KBqG7S2Ako2SljKXRFi+0863PspK74QQ7JpmWwncChY25JTJSbVBYGQk2Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.3.tgz",
+			"integrity": "sha512-0r36VeEJ4efwmofxVJRXDjVRP2jTmv877zc+i+Pc7MNsIr38NfsjkQj23AfF7l0WbB+RQ7VUb+LDiqC/KY/M/A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.3.tgz",
+			"integrity": "sha512-wgO6rc7uGStH22nur4aLFcq7Wh86bE9cOFmfTr/yxN3BXvDEdCSXyKkO+U5JIt53eTOgC47v9k/C1bITWL/Teg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.3.tgz",
+			"integrity": "sha512-FdVl64OIuiKjgXBjwZaJLKp0eaEckifbhn10dXWhysMJkWblg3OEEGKSIyhiD5RSgAya8WzP3DNkngtIg3Nt7g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@eslint-community/eslint-utils": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+			"integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eslint-visitor-keys": "^3.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+			}
+		},
+		"node_modules/@eslint-community/regexpp": {
+			"version": "4.11.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.1.tgz",
+			"integrity": "sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@eslint/eslintrc": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^6.12.4",
+				"debug": "^4.3.2",
+				"espree": "^9.6.0",
+				"globals": "^13.19.0",
+				"ignore": "^5.2.0",
+				"import-fresh": "^3.2.1",
+				"js-yaml": "^4.1.0",
+				"minimatch": "^3.1.2",
+				"strip-json-comments": "^3.1.1"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@eslint/eslintrc/node_modules/globals": {
+			"version": "13.24.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"type-fest": "^0.20.2"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@eslint/js": {
+			"version": "9.11.1",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.11.1.tgz",
+			"integrity": "sha512-/qu+TWz8WwPWc7/HcIJKi+c+MOm46GdVaSlTTQcaqaL53+GsoA6MxWp5PtTx48qbSP7ylM1Kn7nhvkugfJvRSA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@humanwhocodes/config-array": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+			"integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+			"deprecated": "Use @eslint/config-array instead",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@humanwhocodes/object-schema": "^2.0.3",
+				"debug": "^4.3.1",
+				"minimatch": "^3.0.5"
+			},
+			"engines": {
+				"node": ">=10.10.0"
+			}
+		},
+		"node_modules/@humanwhocodes/module-importer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.22"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/nzakas"
+			}
+		},
+		"node_modules/@humanwhocodes/object-schema": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+			"deprecated": "Use @eslint/object-schema instead",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@nodelib/fs.scandir": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@nodelib/fs.stat": "2.0.5",
+				"run-parallel": "^1.1.9"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@nodelib/fs.stat": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@nodelib/fs.walk": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@nodelib/fs.scandir": "2.1.5",
+				"fastq": "^1.6.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@types/codemirror": {
+			"version": "5.60.8",
+			"resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
+			"integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/tern": "*"
+			}
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/json-schema": {
+			"version": "7.0.15",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "16.18.108",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.108.tgz",
+			"integrity": "sha512-fj42LD82fSv6yN9C6Q4dzS+hujHj+pTv0IpRR3kI20fnYeS0ytBpjFO9OjmDowSPPt4lNKN46JLaKbCyP+BW2A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/tern": {
+			"version": "0.23.9",
+			"resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
+			"integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "*"
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin": {
+			"version": "5.29.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.29.0.tgz",
+			"integrity": "sha512-kgTsISt9pM53yRFQmLZ4npj99yGl3x3Pl7z4eA66OuTzAGC4bQB5H5fuLwPnqTKU3yyrrg4MIhjF17UYnL4c0w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/scope-manager": "5.29.0",
+				"@typescript-eslint/type-utils": "5.29.0",
+				"@typescript-eslint/utils": "5.29.0",
+				"debug": "^4.3.4",
+				"functional-red-black-tree": "^1.0.1",
+				"ignore": "^5.2.0",
+				"regexpp": "^3.2.0",
+				"semver": "^7.3.7",
+				"tsutils": "^3.21.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/parser": "^5.0.0",
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/parser": {
+			"version": "5.29.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.29.0.tgz",
+			"integrity": "sha512-ruKWTv+x0OOxbzIw9nW5oWlUopvP/IQDjB5ZqmTglLIoDTctLlAJpAQFpNPJP/ZI7hTT9sARBosEfaKbcFuECw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"@typescript-eslint/scope-manager": "5.29.0",
+				"@typescript-eslint/types": "5.29.0",
+				"@typescript-eslint/typescript-estree": "5.29.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/scope-manager": {
+			"version": "5.29.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.29.0.tgz",
+			"integrity": "sha512-etbXUT0FygFi2ihcxDZjz21LtC+Eps9V2xVx09zFoN44RRHPrkMflidGMI+2dUs821zR1tDS6Oc9IXxIjOUZwA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "5.29.0",
+				"@typescript-eslint/visitor-keys": "5.29.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils": {
+			"version": "5.29.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.29.0.tgz",
+			"integrity": "sha512-JK6bAaaiJozbox3K220VRfCzLa9n0ib/J+FHIwnaV3Enw/TO267qe0pM1b1QrrEuy6xun374XEAsRlA86JJnyg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/utils": "5.29.0",
+				"debug": "^4.3.4",
+				"tsutils": "^3.21.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "*"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/types": {
+			"version": "5.29.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.29.0.tgz",
+			"integrity": "sha512-X99VbqvAXOMdVyfFmksMy3u8p8yoRGITgU1joBJPzeYa0rhdf5ok9S56/itRoUSh99fiDoMtarSIJXo7H/SnOg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree": {
+			"version": "5.29.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.29.0.tgz",
+			"integrity": "sha512-mQvSUJ/JjGBdvo+1LwC+GY2XmSYjK1nAaVw2emp/E61wEVYEyibRHCqm1I1vEKbXCpUKuW4G7u9ZCaZhJbLoNQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"@typescript-eslint/types": "5.29.0",
+				"@typescript-eslint/visitor-keys": "5.29.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"semver": "^7.3.7",
+				"tsutils": "^3.21.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/utils": {
+			"version": "5.29.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.29.0.tgz",
+			"integrity": "sha512-3Eos6uP1nyLOBayc/VUdKZikV90HahXE5Dx9L5YlSd/7ylQPXhLk1BYb29SDgnBnTp+jmSZUU0QxUiyHgW4p7A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/json-schema": "^7.0.9",
+				"@typescript-eslint/scope-manager": "5.29.0",
+				"@typescript-eslint/types": "5.29.0",
+				"@typescript-eslint/typescript-estree": "5.29.0",
+				"eslint-scope": "^5.1.1",
+				"eslint-utils": "^3.0.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/visitor-keys": {
+			"version": "5.29.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.29.0.tgz",
+			"integrity": "sha512-Hpb/mCWsjILvikMQoZIE3voc9wtQcS0A9FUw3h8bhr9UxBdtI/tw1ZDZUOXHXLOVMedKCH5NxyzATwnU78bWCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "5.29.0",
+				"eslint-visitor-keys": "^3.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@ungap/structured-clone": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/acorn": {
+			"version": "8.12.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+			"integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/acorn-jsx": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/ajv": {
+			"version": "6.12.6",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true,
+			"license": "Python-2.0"
+		},
+		"node_modules/array-union": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/braces": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fill-range": "^7.1.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/builtin-modules": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+			"integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/callsites": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/cross-spawn": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+			"integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/deep-is": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/dir-glob": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-type": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/doctrine": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"esutils": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/esbuild": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.3.tgz",
+			"integrity": "sha512-9n3AsBRe6sIyOc6kmoXg2ypCLgf3eZSraWFRpnkto+svt8cZNuKTkb1bhQcitBcvIqjNiK7K0J3KPmwGSfkA8g==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"optionalDependencies": {
+				"@esbuild/android-arm": "0.17.3",
+				"@esbuild/android-arm64": "0.17.3",
+				"@esbuild/android-x64": "0.17.3",
+				"@esbuild/darwin-arm64": "0.17.3",
+				"@esbuild/darwin-x64": "0.17.3",
+				"@esbuild/freebsd-arm64": "0.17.3",
+				"@esbuild/freebsd-x64": "0.17.3",
+				"@esbuild/linux-arm": "0.17.3",
+				"@esbuild/linux-arm64": "0.17.3",
+				"@esbuild/linux-ia32": "0.17.3",
+				"@esbuild/linux-loong64": "0.17.3",
+				"@esbuild/linux-mips64el": "0.17.3",
+				"@esbuild/linux-ppc64": "0.17.3",
+				"@esbuild/linux-riscv64": "0.17.3",
+				"@esbuild/linux-s390x": "0.17.3",
+				"@esbuild/linux-x64": "0.17.3",
+				"@esbuild/netbsd-x64": "0.17.3",
+				"@esbuild/openbsd-x64": "0.17.3",
+				"@esbuild/sunos-x64": "0.17.3",
+				"@esbuild/win32-arm64": "0.17.3",
+				"@esbuild/win32-ia32": "0.17.3",
+				"@esbuild/win32-x64": "0.17.3"
+			}
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint": {
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+			"integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.2.0",
+				"@eslint-community/regexpp": "^4.6.1",
+				"@eslint/eslintrc": "^2.1.4",
+				"@eslint/js": "8.57.1",
+				"@humanwhocodes/config-array": "^0.13.0",
+				"@humanwhocodes/module-importer": "^1.0.1",
+				"@nodelib/fs.walk": "^1.2.8",
+				"@ungap/structured-clone": "^1.2.0",
+				"ajv": "^6.12.4",
+				"chalk": "^4.0.0",
+				"cross-spawn": "^7.0.2",
+				"debug": "^4.3.2",
+				"doctrine": "^3.0.0",
+				"escape-string-regexp": "^4.0.0",
+				"eslint-scope": "^7.2.2",
+				"eslint-visitor-keys": "^3.4.3",
+				"espree": "^9.6.1",
+				"esquery": "^1.4.2",
+				"esutils": "^2.0.2",
+				"fast-deep-equal": "^3.1.3",
+				"file-entry-cache": "^6.0.1",
+				"find-up": "^5.0.0",
+				"glob-parent": "^6.0.2",
+				"globals": "^13.19.0",
+				"graphemer": "^1.4.0",
+				"ignore": "^5.2.0",
+				"imurmurhash": "^0.1.4",
+				"is-glob": "^4.0.0",
+				"is-path-inside": "^3.0.3",
+				"js-yaml": "^4.1.0",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"levn": "^0.4.1",
+				"lodash.merge": "^4.6.2",
+				"minimatch": "^3.1.2",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.9.3",
+				"strip-ansi": "^6.0.1",
+				"text-table": "^0.2.0"
+			},
+			"bin": {
+				"eslint": "bin/eslint.js"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-scope": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"esrecurse": "^4.3.0",
+				"estraverse": "^4.1.1"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/eslint-utils": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eslint-visitor-keys": "^2.0.0"
+			},
+			"engines": {
+				"node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			},
+			"peerDependencies": {
+				"eslint": ">=5"
+			}
+		},
+		"node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+			"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/eslint-visitor-keys": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint/node_modules/@eslint/js": {
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+			"integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/eslint/node_modules/eslint-scope": {
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+			"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"esrecurse": "^4.3.0",
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint/node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/eslint/node_modules/globals": {
+			"version": "13.24.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"type-fest": "^0.20.2"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/espree": {
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"acorn": "^8.9.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^3.4.1"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/esquery": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+			"integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"estraverse": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/esquery/node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/esrecurse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/esrecurse/node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/estraverse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/fast-glob": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@nodelib/fs.stat": "^2.0.2",
+				"@nodelib/fs.walk": "^1.2.3",
+				"glob-parent": "^5.1.2",
+				"merge2": "^1.3.0",
+				"micromatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=8.6.0"
+			}
+		},
+		"node_modules/fast-glob/node_modules/glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/fast-json-stable-stringify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/fastq": {
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+			"integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"reusify": "^1.0.4"
+			}
+		},
+		"node_modules/file-entry-cache": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"flat-cache": "^3.0.4"
+			},
+			"engines": {
+				"node": "^10.12.0 || >=12.0.0"
+			}
+		},
+		"node_modules/fill-range": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"to-regex-range": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/flat-cache": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+			"integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"flatted": "^3.2.9",
+				"keyv": "^4.5.3",
+				"rimraf": "^3.0.2"
+			},
+			"engines": {
+				"node": "^10.12.0 || >=12.0.0"
+			}
+		},
+		"node_modules/flatted": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
+			"integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/functional-red-black-tree": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+			"integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/glob-parent": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"is-glob": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/globals": {
+			"version": "15.9.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-15.9.0.tgz",
+			"integrity": "sha512-SmSKyLLKFbSr6rptvP8izbyxJL4ILwqO9Jg23UA0sDlGlu58V59D1//I3vlc0KJphVdUR7vMjHIplYnzBxorQA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/globby": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"array-union": "^2.1.0",
+				"dir-glob": "^3.0.1",
+				"fast-glob": "^3.2.9",
+				"ignore": "^5.2.0",
+				"merge2": "^1.4.1",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/graphemer": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/import-fresh": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"parent-module": "^1.0.0",
+				"resolve-from": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.19"
+			}
+		},
+		"node_modules/inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-glob": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-extglob": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-number": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/is-path-inside": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/js-yaml": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/json-buffer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/json-stable-stringify-without-jsonify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/keyv": {
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"json-buffer": "3.0.1"
+			}
+		},
+		"node_modules/levn": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"prelude-ls": "^1.2.1",
+				"type-check": "~0.4.0"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/lodash.merge": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/merge2": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/micromatch": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"braces": "^3.0.3",
+				"picomatch": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=8.6"
+			}
+		},
+		"node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/moment": {
+			"version": "2.29.4",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+			"integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/npx": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/npx/-/npx-10.2.2.tgz",
+			"integrity": "sha512-eImmySusyeWphzs5iNh791XbZnZG0FSNvM4KSah34pdQQIDsdTDhIwg1sjN3AIVcjGLpbQ/YcfqHPshKZQK1fA==",
+			"bundleDependencies": [
+				"npm",
+				"libnpx"
+			],
+			"deprecated": "This package is now part of the npm CLI.",
+			"license": "ISC",
+			"dependencies": {
+				"libnpx": "10.2.2",
+				"npm": "5.1.0"
+			},
+			"bin": {
+				"npx": "index.js"
+			}
+		},
+		"node_modules/npx/node_modules/ansi-align": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^2.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/ansi-regex": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/balanced-match": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/boxen": {
+			"version": "1.3.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-align": "^2.0.0",
+				"camelcase": "^4.0.0",
+				"chalk": "^2.0.1",
+				"cli-boxes": "^1.0.0",
+				"string-width": "^2.0.0",
+				"term-size": "^1.2.0",
+				"widest-line": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/npx/node_modules/builtins": {
+			"version": "1.0.3",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/camelcase": {
+			"version": "4.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/capture-stack-trace": {
+			"version": "1.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/chalk": {
+			"version": "2.4.2",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/ci-info": {
+			"version": "1.6.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/cli-boxes": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/cliui": {
+			"version": "4.1.0",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^2.1.1",
+				"strip-ansi": "^4.0.0",
+				"wrap-ansi": "^2.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/code-point-at": {
+			"version": "1.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/color-convert": {
+			"version": "1.9.3",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "1.1.3"
+			}
+		},
+		"node_modules/npx/node_modules/color-name": {
+			"version": "1.1.3",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/concat-map": {
+			"version": "0.0.1",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/configstore": {
+			"version": "3.1.2",
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"dot-prop": "^4.1.0",
+				"graceful-fs": "^4.1.2",
+				"make-dir": "^1.0.0",
+				"unique-string": "^1.0.0",
+				"write-file-atomic": "^2.0.0",
+				"xdg-basedir": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/create-error-class": {
+			"version": "3.0.2",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"capture-stack-trace": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/cross-spawn": {
+			"version": "5.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"lru-cache": "^4.0.1",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
+			}
+		},
+		"node_modules/npx/node_modules/crypto-random-string": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/decamelize": {
+			"version": "1.2.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/deep-extend": {
+			"version": "0.6.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/dot-prop": {
+			"version": "4.2.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-obj": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/dotenv": {
+			"version": "5.0.1",
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=4.6.0"
+			}
+		},
+		"node_modules/npx/node_modules/duplexer3": {
+			"version": "0.1.4",
+			"inBundle": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/npx/node_modules/end-of-stream": {
+			"version": "1.4.4",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"once": "^1.4.0"
+			}
+		},
+		"node_modules/npx/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/npx/node_modules/execa": {
+			"version": "0.7.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"cross-spawn": "^5.0.1",
+				"get-stream": "^3.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/find-up": {
+			"version": "2.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/fs.realpath": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/get-caller-file": {
+			"version": "1.0.3",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/get-stream": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/glob": {
+			"version": "7.1.6",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npx/node_modules/global-dirs": {
+			"version": "0.1.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ini": "^1.3.4"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/got": {
+			"version": "6.7.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"create-error-class": "^3.0.0",
+				"duplexer3": "^0.1.4",
+				"get-stream": "^3.0.0",
+				"is-redirect": "^1.0.0",
+				"is-retry-allowed": "^1.0.0",
+				"is-stream": "^1.0.0",
+				"lowercase-keys": "^1.0.0",
+				"safe-buffer": "^5.0.1",
+				"timed-out": "^4.0.0",
+				"unzip-response": "^2.0.1",
+				"url-parse-lax": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/graceful-fs": {
+			"version": "4.2.3",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/has-flag": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/hosted-git-info": {
+			"version": "2.8.5",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/import-lazy": {
+			"version": "2.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/imurmurhash": {
+			"version": "0.1.4",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.19"
+			}
+		},
+		"node_modules/npx/node_modules/inflight": {
+			"version": "1.0.6",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"node_modules/npx/node_modules/inherits": {
+			"version": "2.0.4",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/ini": {
+			"version": "1.3.5",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/npx/node_modules/invert-kv": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/is-ci": {
+			"version": "1.2.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ci-info": "^1.5.0"
+			},
+			"bin": {
+				"is-ci": "bin.js"
+			}
+		},
+		"node_modules/npx/node_modules/is-fullwidth-code-point": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/is-installed-globally": {
+			"version": "0.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"global-dirs": "^0.1.0",
+				"is-path-inside": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/is-npm": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/is-obj": {
+			"version": "1.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/is-path-inside": {
+			"version": "1.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-is-inside": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/is-redirect": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/is-retry-allowed": {
+			"version": "1.2.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/is-stream": {
+			"version": "1.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/isexe": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/latest-version": {
+			"version": "3.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"package-json": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/lcid": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"invert-kv": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/npx/node_modules/libnpx": {
+			"version": "10.2.2",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"dotenv": "^5.0.1",
+				"npm-package-arg": "^6.0.0",
+				"rimraf": "^2.6.2",
+				"safe-buffer": "^5.1.0",
+				"update-notifier": "^2.3.0",
+				"which": "^1.3.0",
+				"y18n": "^4.0.0",
+				"yargs": "^11.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/locate-path": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^2.0.0",
+				"path-exists": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/lowercase-keys": {
+			"version": "1.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/lru-cache": {
+			"version": "4.1.5",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
+			}
+		},
+		"node_modules/npx/node_modules/make-dir": {
+			"version": "1.3.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"pify": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/map-age-cleaner": {
+			"version": "0.1.3",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-defer": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/npx/node_modules/mem": {
+			"version": "4.3.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"map-age-cleaner": "^0.1.1",
+				"mimic-fn": "^2.0.0",
+				"p-is-promise": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/npx/node_modules/mimic-fn": {
+			"version": "2.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/npx/node_modules/minimatch": {
+			"version": "3.0.4",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/npx/node_modules/minimist": {
+			"version": "1.2.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/nice-try": {
+			"version": "1.0.5",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm": {
+			"version": "5.1.0",
+			"bundleDependencies": [
+				"abbrev",
+				"ansi-regex",
+				"ansicolors",
+				"ansistyles",
+				"aproba",
+				"archy",
+				"cacache",
+				"call-limit",
+				"bluebird",
+				"chownr",
+				"cmd-shim",
+				"columnify",
+				"config-chain",
+				"debuglog",
+				"detect-indent",
+				"dezalgo",
+				"editor",
+				"fs-vacuum",
+				"fs-write-stream-atomic",
+				"fstream",
+				"fstream-npm",
+				"glob",
+				"graceful-fs",
+				"has-unicode",
+				"hosted-git-info",
+				"iferr",
+				"imurmurhash",
+				"inflight",
+				"inherits",
+				"ini",
+				"init-package-json",
+				"JSONStream",
+				"lazy-property",
+				"lockfile",
+				"lodash._baseindexof",
+				"lodash._baseuniq",
+				"lodash._bindcallback",
+				"lodash._cacheindexof",
+				"lodash._createcache",
+				"lodash._getnative",
+				"lodash.clonedeep",
+				"lodash.restparam",
+				"lodash.union",
+				"lodash.uniq",
+				"lodash.without",
+				"lru-cache",
+				"mkdirp",
+				"mississippi",
+				"move-concurrently",
+				"node-gyp",
+				"nopt",
+				"normalize-package-data",
+				"npm-cache-filename",
+				"npm-install-checks",
+				"npm-package-arg",
+				"npm-registry-client",
+				"npm-user-validate",
+				"npmlog",
+				"once",
+				"opener",
+				"osenv",
+				"pacote",
+				"path-is-inside",
+				"promise-inflight",
+				"read",
+				"read-cmd-shim",
+				"read-installed",
+				"read-package-json",
+				"read-package-tree",
+				"readable-stream",
+				"readdir-scoped-modules",
+				"request",
+				"retry",
+				"rimraf",
+				"semver",
+				"sha",
+				"slide",
+				"sorted-object",
+				"sorted-union-stream",
+				"ssri",
+				"strip-ansi",
+				"tar",
+				"text-table",
+				"uid-number",
+				"umask",
+				"unique-filename",
+				"unpipe",
+				"update-notifier",
+				"uuid",
+				"validate-npm-package-license",
+				"validate-npm-package-name",
+				"which",
+				"wrappy",
+				"write-file-atomic",
+				"safe-buffer",
+				"worker-farm"
+			],
+			"inBundle": true,
+			"license": "Artistic-2.0",
+			"dependencies": {
+				"abbrev": "~1.1.0",
+				"ansi-regex": "~3.0.0",
+				"ansicolors": "~0.3.2",
+				"ansistyles": "~0.1.3",
+				"aproba": "~1.1.2",
+				"archy": "~1.0.0",
+				"bluebird": "~3.5.0",
+				"cacache": "~9.2.9",
+				"call-limit": "~1.1.0",
+				"chownr": "~1.0.1",
+				"cmd-shim": "~2.0.2",
+				"columnify": "~1.5.4",
+				"config-chain": "~1.1.11",
+				"debuglog": "*",
+				"detect-indent": "~5.0.0",
+				"dezalgo": "~1.0.3",
+				"editor": "~1.0.0",
+				"fs-vacuum": "~1.2.10",
+				"fs-write-stream-atomic": "~1.0.10",
+				"fstream": "~1.0.11",
+				"fstream-npm": "~1.2.1",
+				"glob": "~7.1.2",
+				"graceful-fs": "~4.1.11",
+				"has-unicode": "~2.0.1",
+				"hosted-git-info": "~2.5.0",
+				"iferr": "~0.1.5",
+				"imurmurhash": "*",
+				"inflight": "~1.0.6",
+				"inherits": "~2.0.3",
+				"ini": "~1.3.4",
+				"init-package-json": "~1.10.1",
+				"JSONStream": "~1.3.1",
+				"lazy-property": "~1.0.0",
+				"lockfile": "~1.0.3",
+				"lodash._baseindexof": "*",
+				"lodash._baseuniq": "~4.6.0",
+				"lodash._bindcallback": "*",
+				"lodash._cacheindexof": "*",
+				"lodash._createcache": "*",
+				"lodash._getnative": "*",
+				"lodash.clonedeep": "~4.5.0",
+				"lodash.restparam": "*",
+				"lodash.union": "~4.6.0",
+				"lodash.uniq": "~4.5.0",
+				"lodash.without": "~4.4.0",
+				"lru-cache": "~4.1.1",
+				"mississippi": "~1.3.0",
+				"mkdirp": "~0.5.1",
+				"move-concurrently": "~1.0.1",
+				"node-gyp": "~3.6.2",
+				"nopt": "~4.0.1",
+				"normalize-package-data": "~2.4.0",
+				"npm-cache-filename": "~1.0.2",
+				"npm-install-checks": "~3.0.0",
+				"npm-package-arg": "~5.1.2",
+				"npm-registry-client": "~8.4.0",
+				"npm-user-validate": "~1.0.0",
+				"npmlog": "~4.1.2",
+				"once": "~1.4.0",
+				"opener": "~1.4.3",
+				"osenv": "~0.1.4",
+				"pacote": "~2.7.38",
+				"path-is-inside": "~1.0.2",
+				"promise-inflight": "~1.0.1",
+				"read": "~1.0.7",
+				"read-cmd-shim": "~1.0.1",
+				"read-installed": "~4.0.3",
+				"read-package-json": "~2.0.9",
+				"read-package-tree": "~5.1.6",
+				"readable-stream": "~2.3.2",
+				"readdir-scoped-modules": "*",
+				"request": "~2.81.0",
+				"retry": "~0.10.1",
+				"rimraf": "~2.6.1",
+				"safe-buffer": "~5.1.1",
+				"semver": "~5.3.0",
+				"sha": "~2.0.1",
+				"slide": "~1.1.6",
+				"sorted-object": "~2.0.1",
+				"sorted-union-stream": "~2.1.3",
+				"ssri": "~4.1.6",
+				"strip-ansi": "~4.0.0",
+				"tar": "~2.2.1",
+				"text-table": "~0.2.0",
+				"uid-number": "0.0.6",
+				"umask": "~1.1.0",
+				"unique-filename": "~1.1.0",
+				"unpipe": "~1.0.0",
+				"update-notifier": "~2.2.0",
+				"uuid": "~3.1.0",
+				"validate-npm-package-license": "*",
+				"validate-npm-package-name": "~3.0.0",
+				"which": "~1.2.14",
+				"worker-farm": "~1.3.1",
+				"wrappy": "~1.0.2",
+				"write-file-atomic": "~2.1.0"
+			},
+			"bin": {
+				"npm": "bin/npm-cli.js"
+			}
+		},
+		"node_modules/npx/node_modules/npm-package-arg": {
+			"version": "6.1.1",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"hosted-git-info": "^2.7.1",
+				"osenv": "^0.1.5",
+				"semver": "^5.6.0",
+				"validate-npm-package-name": "^3.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm-run-path": {
+			"version": "2.0.2",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/abbrev": {
+			"version": "1.1.0",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/ansi-regex": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/ansicolors": {
+			"version": "0.3.2",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/ansistyles": {
+			"version": "0.1.3",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/aproba": {
+			"version": "1.1.2",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/archy": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/bluebird": {
+			"version": "3.5.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/cacache": {
+			"version": "9.2.9",
+			"inBundle": true,
+			"license": "CC0-1.0",
+			"dependencies": {
+				"bluebird": "^3.5.0",
+				"chownr": "^1.0.1",
+				"glob": "^7.1.2",
+				"graceful-fs": "^4.1.11",
+				"lru-cache": "^4.1.1",
+				"mississippi": "^1.3.0",
+				"mkdirp": "^0.5.1",
+				"move-concurrently": "^1.0.1",
+				"promise-inflight": "^1.0.1",
+				"rimraf": "^2.6.1",
+				"ssri": "^4.1.6",
+				"unique-filename": "^1.1.0",
+				"y18n": "^3.2.1"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/cacache/node_modules/lru-cache": {
+			"version": "4.1.1",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/cacache/node_modules/lru-cache/node_modules/pseudomap": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/cacache/node_modules/lru-cache/node_modules/yallist": {
+			"version": "2.1.2",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/cacache/node_modules/y18n": {
+			"version": "3.2.1",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/call-limit": {
+			"version": "1.1.0",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/chownr": {
+			"version": "1.0.1",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/cmd-shim": {
+			"version": "2.0.2",
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"graceful-fs": "^4.1.2",
+				"mkdirp": "~0.5.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/columnify": {
+			"version": "1.5.4",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"strip-ansi": "^3.0.0",
+				"wcwidth": "^1.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/columnify/node_modules/strip-ansi": {
+			"version": "3.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/columnify/node_modules/strip-ansi/node_modules/ansi-regex": {
+			"version": "2.1.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/columnify/node_modules/wcwidth": {
+			"version": "1.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"defaults": "^1.0.3"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/columnify/node_modules/wcwidth/node_modules/defaults": {
+			"version": "1.0.3",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"clone": "^1.0.2"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/columnify/node_modules/wcwidth/node_modules/defaults/node_modules/clone": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/config-chain": {
+			"version": "1.1.11",
+			"inBundle": true,
+			"dependencies": {
+				"ini": "^1.3.4",
+				"proto-list": "~1.2.1"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/config-chain/node_modules/proto-list": {
+			"version": "1.2.4",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/debuglog": {
+			"version": "1.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/detect-indent": {
+			"version": "5.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/dezalgo": {
+			"version": "1.0.3",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"asap": "^2.0.0",
+				"wrappy": "1"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/dezalgo/node_modules/asap": {
+			"version": "2.0.5",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/editor": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/fs-vacuum": {
+			"version": "1.2.10",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"graceful-fs": "^4.1.2",
+				"path-is-inside": "^1.0.1",
+				"rimraf": "^2.5.2"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/fs-write-stream-atomic": {
+			"version": "1.0.10",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"graceful-fs": "^4.1.2",
+				"iferr": "^0.1.5",
+				"imurmurhash": "^0.1.4",
+				"readable-stream": "1 || 2"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/fstream": {
+			"version": "1.0.11",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"graceful-fs": "^4.1.2",
+				"inherits": "~2.0.0",
+				"mkdirp": ">=0.5 0",
+				"rimraf": "2"
+			},
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/fstream-npm": {
+			"version": "1.2.1",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"fstream-ignore": "^1.0.0",
+				"inherits": "2"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/fstream-npm/node_modules/fstream-ignore": {
+			"version": "1.0.5",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"fstream": "^1.0.0",
+				"inherits": "2",
+				"minimatch": "^3.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/fstream-npm/node_modules/fstream-ignore/node_modules/minimatch": {
+			"version": "3.0.4",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/fstream-npm/node_modules/fstream-ignore/node_modules/minimatch/node_modules/brace-expansion": {
+			"version": "1.1.8",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/fstream-npm/node_modules/fstream-ignore/node_modules/minimatch/node_modules/brace-expansion/node_modules/balanced-match": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/fstream-npm/node_modules/fstream-ignore/node_modules/minimatch/node_modules/brace-expansion/node_modules/concat-map": {
+			"version": "0.0.1",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/glob": {
+			"version": "7.1.2",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/glob/node_modules/fs.realpath": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/glob/node_modules/minimatch": {
+			"version": "3.0.4",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/glob/node_modules/minimatch/node_modules/brace-expansion": {
+			"version": "1.1.8",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/glob/node_modules/minimatch/node_modules/brace-expansion/node_modules/balanced-match": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/glob/node_modules/minimatch/node_modules/brace-expansion/node_modules/concat-map": {
+			"version": "0.0.1",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/glob/node_modules/path-is-absolute": {
+			"version": "1.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/graceful-fs": {
+			"version": "4.1.11",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/has-unicode": {
+			"version": "2.0.1",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/hosted-git-info": {
+			"version": "2.5.0",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/iferr": {
+			"version": "0.1.5",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/imurmurhash": {
+			"version": "0.1.4",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.19"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/inflight": {
+			"version": "1.0.6",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/inherits": {
+			"version": "2.0.3",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/ini": {
+			"version": "1.3.4",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/init-package-json": {
+			"version": "1.10.1",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"glob": "^7.1.1",
+				"npm-package-arg": "^4.0.0 || ^5.0.0",
+				"promzard": "^0.3.0",
+				"read": "~1.0.1",
+				"read-package-json": "1 || 2",
+				"semver": "2.x || 3.x || 4 || 5",
+				"validate-npm-package-license": "^3.0.1",
+				"validate-npm-package-name": "^3.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/init-package-json/node_modules/promzard": {
+			"version": "0.3.0",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"read": "1"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/JSONStream": {
+			"version": "1.3.1",
+			"inBundle": true,
+			"license": "(MIT OR Apache-2.0)",
+			"dependencies": {
+				"jsonparse": "^1.2.0",
+				"through": ">=2.2.7 <3"
+			},
+			"bin": {
+				"JSONStream": "index.js"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/JSONStream/node_modules/jsonparse": {
+			"version": "1.3.1",
+			"engines": [
+				"node >= 0.2.0"
+			],
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/JSONStream/node_modules/through": {
+			"version": "2.3.8",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/lazy-property": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/lockfile": {
+			"version": "1.0.3",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/lodash._baseindexof": {
+			"version": "3.1.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/lodash._baseuniq": {
+			"version": "4.6.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"lodash._createset": "~4.0.0",
+				"lodash._root": "~3.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/lodash._baseuniq/node_modules/lodash._createset": {
+			"version": "4.0.3",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/lodash._baseuniq/node_modules/lodash._root": {
+			"version": "3.0.1",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/lodash._bindcallback": {
+			"version": "3.0.1",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/lodash._cacheindexof": {
+			"version": "3.0.2",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/lodash._createcache": {
+			"version": "3.1.2",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"lodash._getnative": "^3.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/lodash._getnative": {
+			"version": "3.9.1",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/lodash.clonedeep": {
+			"version": "4.5.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/lodash.restparam": {
+			"version": "3.6.1",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/lodash.union": {
+			"version": "4.6.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/lodash.uniq": {
+			"version": "4.5.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/lodash.without": {
+			"version": "4.4.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/lru-cache": {
+			"version": "4.1.1",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/lru-cache/node_modules/pseudomap": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/lru-cache/node_modules/yallist": {
+			"version": "2.1.2",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/mississippi": {
+			"version": "1.3.0",
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"concat-stream": "^1.5.0",
+				"duplexify": "^3.4.2",
+				"end-of-stream": "^1.1.0",
+				"flush-write-stream": "^1.0.0",
+				"from2": "^2.1.0",
+				"parallel-transform": "^1.1.0",
+				"pump": "^1.0.0",
+				"pumpify": "^1.3.3",
+				"stream-each": "^1.1.0",
+				"through2": "^2.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/concat-stream": {
+			"version": "1.6.0",
+			"engines": [
+				"node >= 0.8"
+			],
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.2.2",
+				"typedarray": "^0.0.6"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/concat-stream/node_modules/typedarray": {
+			"version": "0.0.6",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/duplexify": {
+			"version": "3.5.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"end-of-stream": "1.0.0",
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.0",
+				"stream-shift": "^1.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/duplexify/node_modules/end-of-stream": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"once": "~1.3.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/duplexify/node_modules/end-of-stream/node_modules/once": {
+			"version": "1.3.3",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/duplexify/node_modules/stream-shift": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/end-of-stream": {
+			"version": "1.4.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"once": "^1.4.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/flush-write-stream": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/from2": {
+			"version": "2.3.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/parallel-transform": {
+			"version": "1.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"cyclist": "~0.2.2",
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.1.5"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/parallel-transform/node_modules/cyclist": {
+			"version": "0.2.2",
+			"inBundle": true
+		},
+		"node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/pump": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/pumpify": {
+			"version": "1.3.5",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"duplexify": "^3.1.2",
+				"inherits": "^2.0.1",
+				"pump": "^1.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/stream-each": {
+			"version": "1.2.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"stream-shift": "^1.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/stream-each/node_modules/stream-shift": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/through2": {
+			"version": "2.0.3",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"readable-stream": "^2.1.5",
+				"xtend": "~4.0.1"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/through2/node_modules/xtend": {
+			"version": "4.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/mkdirp": {
+			"version": "0.5.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"minimist": "0.0.8"
+			},
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/mkdirp/node_modules/minimist": {
+			"version": "0.0.8",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/move-concurrently": {
+			"version": "1.0.1",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"aproba": "^1.1.1",
+				"copy-concurrently": "^1.0.0",
+				"fs-write-stream-atomic": "^1.0.8",
+				"mkdirp": "^0.5.1",
+				"rimraf": "^2.5.4",
+				"run-queue": "^1.0.3"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/move-concurrently/node_modules/copy-concurrently": {
+			"version": "1.0.3",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"aproba": "^1.1.1",
+				"fs-write-stream-atomic": "^1.0.8",
+				"iferr": "^0.1.5",
+				"mkdirp": "^0.5.1",
+				"rimraf": "^2.5.4",
+				"run-queue": "^1.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/move-concurrently/node_modules/run-queue": {
+			"version": "1.0.3",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"aproba": "^1.1.1"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/node-gyp": {
+			"version": "3.6.2",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"fstream": "^1.0.0",
+				"glob": "^7.0.3",
+				"graceful-fs": "^4.1.2",
+				"minimatch": "^3.0.2",
+				"mkdirp": "^0.5.0",
+				"nopt": "2 || 3",
+				"npmlog": "0 || 1 || 2 || 3 || 4",
+				"osenv": "0",
+				"request": "2",
+				"rimraf": "2",
+				"semver": "~5.3.0",
+				"tar": "^2.0.0",
+				"which": "1"
+			},
+			"bin": {
+				"node-gyp": "bin/node-gyp.js"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
+			"version": "3.0.4",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/node-gyp/node_modules/minimatch/node_modules/brace-expansion": {
+			"version": "1.1.8",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/node-gyp/node_modules/minimatch/node_modules/brace-expansion/node_modules/balanced-match": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/node-gyp/node_modules/minimatch/node_modules/brace-expansion/node_modules/concat-map": {
+			"version": "0.0.1",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
+			"version": "3.0.6",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"abbrev": "1"
+			},
+			"bin": {
+				"nopt": "bin/nopt.js"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/nopt": {
+			"version": "4.0.1",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"abbrev": "1",
+				"osenv": "^0.1.4"
+			},
+			"bin": {
+				"nopt": "bin/nopt.js"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/normalize-package-data": {
+			"version": "2.4.0",
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"hosted-git-info": "^2.1.4",
+				"is-builtin-module": "^1.0.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/normalize-package-data/node_modules/is-builtin-module": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"builtin-modules": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/normalize-package-data/node_modules/is-builtin-module/node_modules/builtin-modules": {
+			"version": "1.1.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/npm-cache-filename": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/npm-install-checks": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"semver": "^2.3.0 || 3.x || 4 || 5"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/npm-package-arg": {
+			"version": "5.1.2",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"hosted-git-info": "^2.4.2",
+				"osenv": "^0.1.4",
+				"semver": "^5.1.0",
+				"validate-npm-package-name": "^3.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/npm-registry-client": {
+			"version": "8.4.0",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"concat-stream": "^1.5.2",
+				"graceful-fs": "^4.1.6",
+				"normalize-package-data": "~1.0.1 || ^2.0.0",
+				"npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0",
+				"once": "^1.3.3",
+				"request": "^2.74.0",
+				"retry": "^0.10.0",
+				"semver": "2 >=2.2.1 || 3.x || 4 || 5",
+				"slide": "^1.1.3",
+				"ssri": "^4.1.2"
+			},
+			"optionalDependencies": {
+				"npmlog": "2 || ^3.1.0 || ^4.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/npm-registry-client/node_modules/concat-stream": {
+			"version": "1.6.0",
+			"engines": [
+				"node >= 0.8"
+			],
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.2.2",
+				"typedarray": "^0.0.6"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/npm-registry-client/node_modules/concat-stream/node_modules/typedarray": {
+			"version": "0.0.6",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/npm-user-validate": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/npmlog": {
+			"version": "4.1.2",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"are-we-there-yet": "~1.1.2",
+				"console-control-strings": "~1.1.0",
+				"gauge": "~2.7.3",
+				"set-blocking": "~2.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/npmlog/node_modules/are-we-there-yet": {
+			"version": "1.1.4",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"delegates": "^1.0.0",
+				"readable-stream": "^2.0.6"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/npmlog/node_modules/are-we-there-yet/node_modules/delegates": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/npmlog/node_modules/console-control-strings": {
+			"version": "1.1.0",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/npmlog/node_modules/gauge": {
+			"version": "2.7.4",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"aproba": "^1.0.3",
+				"console-control-strings": "^1.0.0",
+				"has-unicode": "^2.0.0",
+				"object-assign": "^4.1.0",
+				"signal-exit": "^3.0.0",
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1",
+				"wide-align": "^1.1.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/npmlog/node_modules/gauge/node_modules/object-assign": {
+			"version": "4.1.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/npmlog/node_modules/gauge/node_modules/signal-exit": {
+			"version": "3.0.2",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/npmlog/node_modules/gauge/node_modules/string-width": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"code-point-at": "^1.0.0",
+				"is-fullwidth-code-point": "^1.0.0",
+				"strip-ansi": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/npmlog/node_modules/gauge/node_modules/string-width/node_modules/code-point-at": {
+			"version": "1.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/npmlog/node_modules/gauge/node_modules/string-width/node_modules/is-fullwidth-code-point": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"number-is-nan": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/npmlog/node_modules/gauge/node_modules/string-width/node_modules/is-fullwidth-code-point/node_modules/number-is-nan": {
+			"version": "1.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/npmlog/node_modules/gauge/node_modules/strip-ansi": {
+			"version": "3.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/npmlog/node_modules/gauge/node_modules/strip-ansi/node_modules/ansi-regex": {
+			"version": "2.1.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/npmlog/node_modules/gauge/node_modules/wide-align": {
+			"version": "1.1.2",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^1.0.2"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/npmlog/node_modules/set-blocking": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/once": {
+			"version": "1.4.0",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/opener": {
+			"version": "1.4.3",
+			"inBundle": true,
+			"license": "(WTFPL OR MIT)",
+			"bin": {
+				"opener": "opener.js"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/osenv": {
+			"version": "0.1.4",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"os-homedir": "^1.0.0",
+				"os-tmpdir": "^1.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/osenv/node_modules/os-homedir": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/osenv/node_modules/os-tmpdir": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote": {
+			"version": "2.7.38",
+			"inBundle": true,
+			"license": "CC0-1.0",
+			"dependencies": {
+				"bluebird": "^3.5.0",
+				"cacache": "^9.2.9",
+				"glob": "^7.1.2",
+				"lru-cache": "^4.1.1",
+				"make-fetch-happen": "^2.4.13",
+				"minimatch": "^3.0.4",
+				"mississippi": "^1.2.0",
+				"normalize-package-data": "^2.4.0",
+				"npm-package-arg": "^5.1.2",
+				"npm-pick-manifest": "^1.0.4",
+				"osenv": "^0.1.4",
+				"promise-inflight": "^1.0.1",
+				"promise-retry": "^1.1.1",
+				"protoduck": "^4.0.0",
+				"safe-buffer": "^5.1.1",
+				"semver": "^5.3.0",
+				"ssri": "^4.1.6",
+				"tar-fs": "^1.15.3",
+				"tar-stream": "^1.5.4",
+				"unique-filename": "^1.1.0",
+				"which": "^1.2.12"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen": {
+			"version": "2.4.13",
+			"inBundle": true,
+			"license": "CC0-1.0",
+			"dependencies": {
+				"agentkeepalive": "^3.3.0",
+				"cacache": "^9.2.9",
+				"http-cache-semantics": "^3.7.3",
+				"http-proxy-agent": "^2.0.0",
+				"https-proxy-agent": "^2.0.0",
+				"lru-cache": "^4.1.1",
+				"mississippi": "^1.2.0",
+				"node-fetch-npm": "^2.0.1",
+				"promise-retry": "^1.1.1",
+				"socks-proxy-agent": "^3.0.0",
+				"ssri": "^4.1.6"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/agentkeepalive": {
+			"version": "3.3.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"humanize-ms": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/agentkeepalive/node_modules/humanize-ms": {
+			"version": "1.2.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/agentkeepalive/node_modules/humanize-ms/node_modules/ms": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/http-cache-semantics": {
+			"version": "3.7.3",
+			"inBundle": true,
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/http-proxy-agent": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "4",
+				"debug": "2"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/http-proxy-agent/node_modules/agent-base": {
+			"version": "4.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"es6-promisify": "^5.0.0"
+			},
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/http-proxy-agent/node_modules/agent-base/node_modules/es6-promisify": {
+			"version": "5.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"es6-promise": "^4.0.3"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/http-proxy-agent/node_modules/agent-base/node_modules/es6-promisify/node_modules/es6-promise": {
+			"version": "4.1.1",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/http-proxy-agent/node_modules/debug": {
+			"version": "2.6.8",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/http-proxy-agent/node_modules/debug/node_modules/ms": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/https-proxy-agent": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^4.1.0",
+				"debug": "^2.4.1"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/https-proxy-agent/node_modules/agent-base": {
+			"version": "4.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"es6-promisify": "^5.0.0"
+			},
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/https-proxy-agent/node_modules/agent-base/node_modules/es6-promisify": {
+			"version": "5.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"es6-promise": "^4.0.3"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/https-proxy-agent/node_modules/agent-base/node_modules/es6-promisify/node_modules/es6-promise": {
+			"version": "4.1.1",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/https-proxy-agent/node_modules/debug": {
+			"version": "2.6.8",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/https-proxy-agent/node_modules/debug/node_modules/ms": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/node-fetch-npm": {
+			"version": "2.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"encoding": "^0.1.11",
+				"json-parse-helpfulerror": "^1.0.3",
+				"safe-buffer": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/node-fetch-npm/node_modules/encoding": {
+			"version": "0.1.12",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"iconv-lite": "~0.4.13"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/node-fetch-npm/node_modules/encoding/node_modules/iconv-lite": {
+			"version": "0.4.18",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/node-fetch-npm/node_modules/json-parse-helpfulerror": {
+			"version": "1.0.3",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"jju": "^1.1.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/node-fetch-npm/node_modules/json-parse-helpfulerror/node_modules/jju": {
+			"version": "1.3.0",
+			"inBundle": true,
+			"license": "WTFPL"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/socks-proxy-agent": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^4.0.1",
+				"socks": "^1.1.10"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/socks-proxy-agent/node_modules/agent-base": {
+			"version": "4.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"es6-promisify": "^5.0.0"
+			},
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/socks-proxy-agent/node_modules/agent-base/node_modules/es6-promisify": {
+			"version": "5.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"es6-promise": "^4.0.3"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/socks-proxy-agent/node_modules/agent-base/node_modules/es6-promisify/node_modules/es6-promise": {
+			"version": "4.1.1",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/socks-proxy-agent/node_modules/socks": {
+			"version": "1.1.10",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ip": "^1.1.4",
+				"smart-buffer": "^1.0.13"
+			},
+			"engines": {
+				"node": ">= 0.10.0",
+				"npm": ">= 1.3.5"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/socks-proxy-agent/node_modules/socks/node_modules/ip": {
+			"version": "1.1.5",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/socks-proxy-agent/node_modules/socks/node_modules/smart-buffer": {
+			"version": "1.1.15",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.10.15",
+				"npm": ">= 1.3.5"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/minimatch": {
+			"version": "3.0.4",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/minimatch/node_modules/brace-expansion": {
+			"version": "1.1.8",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/minimatch/node_modules/brace-expansion/node_modules/balanced-match": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/minimatch/node_modules/brace-expansion/node_modules/concat-map": {
+			"version": "0.0.1",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/npm-pick-manifest": {
+			"version": "1.0.4",
+			"inBundle": true,
+			"license": "CC0-1.0",
+			"dependencies": {
+				"npm-package-arg": "^5.1.2",
+				"semver": "^5.3.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/promise-retry": {
+			"version": "1.1.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"err-code": "^1.0.0",
+				"retry": "^0.10.0"
+			},
+			"engines": {
+				"node": ">=0.12"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/promise-retry/node_modules/err-code": {
+			"version": "1.1.2",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/protoduck": {
+			"version": "4.0.0",
+			"inBundle": true,
+			"license": "CC0-1.0",
+			"dependencies": {
+				"genfun": "^4.0.1"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/protoduck/node_modules/genfun": {
+			"version": "4.0.1",
+			"inBundle": true,
+			"license": "CC0-1.0"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/tar-fs": {
+			"version": "1.15.3",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"chownr": "^1.0.1",
+				"mkdirp": "^0.5.1",
+				"pump": "^1.0.0",
+				"tar-stream": "^1.1.2"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/tar-fs/node_modules/pump": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/tar-fs/node_modules/pump/node_modules/end-of-stream": {
+			"version": "1.4.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"once": "^1.4.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/tar-stream": {
+			"version": "1.5.4",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"bl": "^1.0.0",
+				"end-of-stream": "^1.0.0",
+				"readable-stream": "^2.0.0",
+				"xtend": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/tar-stream/node_modules/bl": {
+			"version": "1.2.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"readable-stream": "^2.0.5"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/tar-stream/node_modules/end-of-stream": {
+			"version": "1.4.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"once": "^1.4.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/tar-stream/node_modules/xtend": {
+			"version": "4.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/path-is-inside": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "(WTFPL OR MIT)"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/promise-inflight": {
+			"version": "1.0.1",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/read": {
+			"version": "1.0.7",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"mute-stream": "~0.0.4"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/read-cmd-shim": {
+			"version": "1.0.1",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"graceful-fs": "^4.1.2"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/read-installed": {
+			"version": "4.0.3",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"debuglog": "^1.0.1",
+				"read-package-json": "^2.0.0",
+				"readdir-scoped-modules": "^1.0.0",
+				"semver": "2 || 3 || 4 || 5",
+				"slide": "~1.1.3",
+				"util-extend": "^1.0.1"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.2"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/read-installed/node_modules/util-extend": {
+			"version": "1.0.3",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/read-package-json": {
+			"version": "2.0.9",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"glob": "^7.1.1",
+				"json-parse-helpfulerror": "^1.0.2",
+				"normalize-package-data": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.2"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/read-package-json/node_modules/json-parse-helpfulerror": {
+			"version": "1.0.3",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"jju": "^1.1.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/read-package-json/node_modules/json-parse-helpfulerror/node_modules/jju": {
+			"version": "1.3.0",
+			"inBundle": true,
+			"license": "WTFPL"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/read-package-tree": {
+			"version": "5.1.6",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"debuglog": "^1.0.1",
+				"dezalgo": "^1.0.0",
+				"once": "^1.3.0",
+				"read-package-json": "^2.0.0",
+				"readdir-scoped-modules": "^1.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/read/node_modules/mute-stream": {
+			"version": "0.0.7",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/readable-stream": {
+			"version": "2.3.2",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~1.0.6",
+				"safe-buffer": "~5.1.0",
+				"string_decoder": "~1.0.0",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/readable-stream/node_modules/core-util-is": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/readable-stream/node_modules/isarray": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/readable-stream/node_modules/process-nextick-args": {
+			"version": "1.0.7",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/readable-stream/node_modules/string_decoder": {
+			"version": "1.0.3",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/readable-stream/node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/readdir-scoped-modules": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"debuglog": "^1.0.1",
+				"dezalgo": "^1.0.0",
+				"graceful-fs": "^4.1.2",
+				"once": "^1.3.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request": {
+			"version": "2.81.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"aws-sign2": "~0.6.0",
+				"aws4": "^1.2.1",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.5",
+				"extend": "~3.0.0",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.1.1",
+				"har-validator": "~4.2.1",
+				"hawk": "~3.1.3",
+				"http-signature": "~1.1.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.7",
+				"oauth-sign": "~0.8.1",
+				"performance-now": "^0.2.0",
+				"qs": "~6.4.0",
+				"safe-buffer": "^5.0.1",
+				"stringstream": "~0.0.4",
+				"tough-cookie": "~2.3.0",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/aws-sign2": {
+			"version": "0.6.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/aws4": {
+			"version": "1.6.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/caseless": {
+			"version": "0.12.0",
+			"inBundle": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/combined-stream": {
+			"version": "1.0.5",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/combined-stream/node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/extend": {
+			"version": "3.0.1",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/forever-agent": {
+			"version": "0.6.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/form-data": {
+			"version": "2.1.4",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.5",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 0.12"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/form-data/node_modules/asynckit": {
+			"version": "0.4.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/har-validator": {
+			"version": "4.2.1",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"ajv": "^4.9.1",
+				"har-schema": "^1.0.5"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/har-validator/node_modules/ajv": {
+			"version": "4.11.8",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"co": "^4.6.0",
+				"json-stable-stringify": "^1.0.1"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/har-validator/node_modules/ajv/node_modules/co": {
+			"version": "4.6.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"iojs": ">= 1.0.0",
+				"node": ">= 0.12.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/har-validator/node_modules/ajv/node_modules/json-stable-stringify": {
+			"version": "1.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"jsonify": "~0.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/har-validator/node_modules/ajv/node_modules/json-stable-stringify/node_modules/jsonify": {
+			"version": "0.0.0",
+			"inBundle": true,
+			"license": "Public Domain",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/har-validator/node_modules/har-schema": {
+			"version": "1.0.5",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/hawk": {
+			"version": "3.1.3",
+			"inBundle": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"boom": "2.x.x",
+				"cryptiles": "2.x.x",
+				"hoek": "2.x.x",
+				"sntp": "1.x.x"
+			},
+			"engines": {
+				"node": ">=0.10.32"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/hawk/node_modules/boom": {
+			"version": "2.10.1",
+			"inBundle": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"hoek": "2.x.x"
+			},
+			"engines": {
+				"node": ">=0.10.40"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/hawk/node_modules/cryptiles": {
+			"version": "2.0.5",
+			"inBundle": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"boom": "2.x.x"
+			},
+			"engines": {
+				"node": ">=0.10.40"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/hawk/node_modules/hoek": {
+			"version": "2.16.3",
+			"inBundle": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.40"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/hawk/node_modules/sntp": {
+			"version": "1.0.9",
+			"inBundle": true,
+			"dependencies": {
+				"hoek": "2.x.x"
+			},
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature": {
+			"version": "1.1.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"assert-plus": "^0.2.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
+			},
+			"engines": {
+				"node": ">=0.8",
+				"npm": ">=1.3.7"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/assert-plus": {
+			"version": "0.2.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/jsprim": {
+			"version": "1.4.0",
+			"engines": [
+				"node >=0.6.0"
+			],
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.0.2",
+				"json-schema": "0.2.3",
+				"verror": "1.3.6"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/jsprim/node_modules/assert-plus": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/jsprim/node_modules/extsprintf": {
+			"version": "1.0.2",
+			"engines": [
+				"node >=0.6.0"
+			],
+			"inBundle": true
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/jsprim/node_modules/json-schema": {
+			"version": "0.2.3",
+			"inBundle": true
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/jsprim/node_modules/verror": {
+			"version": "1.3.6",
+			"engines": [
+				"node >=0.6.0"
+			],
+			"inBundle": true,
+			"dependencies": {
+				"extsprintf": "1.0.2"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk": {
+			"version": "1.13.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"getpass": "^0.1.1"
+			},
+			"bin": {
+				"sshpk-conv": "bin/sshpk-conv",
+				"sshpk-sign": "bin/sshpk-sign",
+				"sshpk-verify": "bin/sshpk-verify"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"optionalDependencies": {
+				"bcrypt-pbkdf": "^1.0.0",
+				"ecc-jsbn": "~0.1.1",
+				"jsbn": "~0.1.0",
+				"tweetnacl": "~0.14.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/node_modules/asn1": {
+			"version": "0.2.3",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/node_modules/assert-plus": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/node_modules/bcrypt-pbkdf": {
+			"version": "1.0.1",
+			"inBundle": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"dependencies": {
+				"tweetnacl": "^0.14.3"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/node_modules/dashdash": {
+			"version": "1.14.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"assert-plus": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/node_modules/ecc-jsbn": {
+			"version": "0.1.1",
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"jsbn": "~0.1.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/node_modules/getpass": {
+			"version": "0.1.7",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"assert-plus": "^1.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/node_modules/jsbn": {
+			"version": "0.1.1",
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/node_modules/tweetnacl": {
+			"version": "0.14.5",
+			"inBundle": true,
+			"license": "Unlicense",
+			"optional": true
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/is-typedarray": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/isstream": {
+			"version": "0.1.2",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/json-stringify-safe": {
+			"version": "5.0.1",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/mime-types": {
+			"version": "2.1.15",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "~1.27.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/mime-types/node_modules/mime-db": {
+			"version": "1.27.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/oauth-sign": {
+			"version": "0.8.2",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/performance-now": {
+			"version": "0.2.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/qs": {
+			"version": "6.4.0",
+			"inBundle": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/stringstream": {
+			"version": "0.0.5",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/tough-cookie": {
+			"version": "2.3.2",
+			"inBundle": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"punycode": "^1.4.1"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/tough-cookie/node_modules/punycode": {
+			"version": "1.4.1",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/request/node_modules/tunnel-agent": {
+			"version": "0.6.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/retry": {
+			"version": "0.10.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/rimraf": {
+			"version": "2.6.1",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"glob": "^7.0.5"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/safe-buffer": {
+			"version": "5.1.1",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/semver": {
+			"version": "5.3.0",
+			"inBundle": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/sha": {
+			"version": "2.0.1",
+			"inBundle": true,
+			"license": "(BSD-2-Clause OR MIT)",
+			"dependencies": {
+				"graceful-fs": "^4.1.2",
+				"readable-stream": "^2.0.2"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/slide": {
+			"version": "1.1.6",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/sorted-object": {
+			"version": "2.0.1",
+			"inBundle": true,
+			"license": "(WTFPL OR MIT)"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/sorted-union-stream": {
+			"version": "2.1.3",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"from2": "^1.3.0",
+				"stream-iterate": "^1.1.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/sorted-union-stream/node_modules/from2": {
+			"version": "1.3.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "~2.0.1",
+				"readable-stream": "~1.1.10"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/sorted-union-stream/node_modules/from2/node_modules/readable-stream": {
+			"version": "1.1.14",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.1",
+				"isarray": "0.0.1",
+				"string_decoder": "~0.10.x"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/sorted-union-stream/node_modules/from2/node_modules/readable-stream/node_modules/core-util-is": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/sorted-union-stream/node_modules/from2/node_modules/readable-stream/node_modules/isarray": {
+			"version": "0.0.1",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/sorted-union-stream/node_modules/from2/node_modules/readable-stream/node_modules/string_decoder": {
+			"version": "0.10.31",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/sorted-union-stream/node_modules/stream-iterate": {
+			"version": "1.2.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"readable-stream": "^2.1.5",
+				"stream-shift": "^1.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/sorted-union-stream/node_modules/stream-iterate/node_modules/stream-shift": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/ssri": {
+			"version": "4.1.6",
+			"inBundle": true,
+			"license": "CC0-1.0",
+			"dependencies": {
+				"safe-buffer": "^5.1.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/strip-ansi": {
+			"version": "4.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/strip-ansi/node_modules/ansi-regex": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/tar": {
+			"version": "2.2.1",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"block-stream": "*",
+				"fstream": "^1.0.2",
+				"inherits": "2"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/tar/node_modules/block-stream": {
+			"version": "0.0.9",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"inherits": "~2.0.0"
+			},
+			"engines": {
+				"node": "0.4 || >=0.5.8"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/text-table": {
+			"version": "0.2.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/uid-number": {
+			"version": "0.0.6",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/umask": {
+			"version": "1.1.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/unique-filename": {
+			"version": "1.1.0",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"unique-slug": "^2.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/unique-filename/node_modules/unique-slug": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"imurmurhash": "^0.1.4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/unpipe": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier": {
+			"version": "2.2.0",
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"boxen": "^1.0.0",
+				"chalk": "^1.0.0",
+				"configstore": "^3.0.0",
+				"import-lazy": "^2.1.0",
+				"is-npm": "^1.0.0",
+				"latest-version": "^3.0.0",
+				"semver-diff": "^2.0.0",
+				"xdg-basedir": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen": {
+			"version": "1.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-align": "^2.0.0",
+				"camelcase": "^4.0.0",
+				"chalk": "^1.1.1",
+				"cli-boxes": "^1.0.0",
+				"string-width": "^2.0.0",
+				"term-size": "^0.1.0",
+				"widest-line": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/ansi-align": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^2.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/camelcase": {
+			"version": "4.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/cli-boxes": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/string-width": {
+			"version": "2.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/string-width/node_modules/is-fullwidth-code-point": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/string-width/node_modules/strip-ansi": {
+			"version": "4.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/term-size": {
+			"version": "0.1.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"execa": "^0.4.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/term-size/node_modules/execa": {
+			"version": "0.4.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"cross-spawn-async": "^2.1.1",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^1.0.0",
+				"object-assign": "^4.0.1",
+				"path-key": "^1.0.0",
+				"strip-eof": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.12"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/term-size/node_modules/execa/node_modules/cross-spawn-async": {
+			"version": "2.2.5",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"lru-cache": "^4.0.0",
+				"which": "^1.2.8"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/term-size/node_modules/execa/node_modules/is-stream": {
+			"version": "1.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/term-size/node_modules/execa/node_modules/npm-run-path": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/term-size/node_modules/execa/node_modules/object-assign": {
+			"version": "4.1.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/term-size/node_modules/execa/node_modules/path-key": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/term-size/node_modules/execa/node_modules/strip-eof": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/widest-line": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"string-width": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/widest-line/node_modules/string-width": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"code-point-at": "^1.0.0",
+				"is-fullwidth-code-point": "^1.0.0",
+				"strip-ansi": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/widest-line/node_modules/string-width/node_modules/code-point-at": {
+			"version": "1.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/widest-line/node_modules/string-width/node_modules/is-fullwidth-code-point": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"number-is-nan": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/widest-line/node_modules/string-width/node_modules/is-fullwidth-code-point/node_modules/number-is-nan": {
+			"version": "1.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/widest-line/node_modules/string-width/node_modules/strip-ansi": {
+			"version": "3.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/widest-line/node_modules/string-width/node_modules/strip-ansi/node_modules/ansi-regex": {
+			"version": "2.1.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/chalk": {
+			"version": "1.1.3",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^2.2.1",
+				"escape-string-regexp": "^1.0.2",
+				"has-ansi": "^2.0.0",
+				"strip-ansi": "^3.0.0",
+				"supports-color": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/chalk/node_modules/ansi-styles": {
+			"version": "2.2.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/chalk/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/chalk/node_modules/has-ansi": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/chalk/node_modules/has-ansi/node_modules/ansi-regex": {
+			"version": "2.1.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/chalk/node_modules/strip-ansi": {
+			"version": "3.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/chalk/node_modules/strip-ansi/node_modules/ansi-regex": {
+			"version": "2.1.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/chalk/node_modules/supports-color": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/configstore": {
+			"version": "3.1.0",
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"dot-prop": "^4.1.0",
+				"graceful-fs": "^4.1.2",
+				"make-dir": "^1.0.0",
+				"unique-string": "^1.0.0",
+				"write-file-atomic": "^2.0.0",
+				"xdg-basedir": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/configstore/node_modules/dot-prop": {
+			"version": "4.1.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-obj": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/configstore/node_modules/dot-prop/node_modules/is-obj": {
+			"version": "1.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/configstore/node_modules/make-dir": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"pify": "^2.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/configstore/node_modules/make-dir/node_modules/pify": {
+			"version": "2.3.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/configstore/node_modules/unique-string": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"crypto-random-string": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/configstore/node_modules/unique-string/node_modules/crypto-random-string": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/import-lazy": {
+			"version": "2.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/is-npm": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version": {
+			"version": "3.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"package-json": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json": {
+			"version": "4.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"got": "^6.7.1",
+				"registry-auth-token": "^3.0.1",
+				"registry-url": "^3.0.3",
+				"semver": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/got": {
+			"version": "6.7.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"create-error-class": "^3.0.0",
+				"duplexer3": "^0.1.4",
+				"get-stream": "^3.0.0",
+				"is-redirect": "^1.0.0",
+				"is-retry-allowed": "^1.0.0",
+				"is-stream": "^1.0.0",
+				"lowercase-keys": "^1.0.0",
+				"safe-buffer": "^5.0.1",
+				"timed-out": "^4.0.0",
+				"unzip-response": "^2.0.1",
+				"url-parse-lax": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/got/node_modules/create-error-class": {
+			"version": "3.0.2",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"capture-stack-trace": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/got/node_modules/create-error-class/node_modules/capture-stack-trace": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/got/node_modules/duplexer3": {
+			"version": "0.1.4",
+			"inBundle": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/got/node_modules/get-stream": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/got/node_modules/is-redirect": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/got/node_modules/is-retry-allowed": {
+			"version": "1.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/got/node_modules/is-stream": {
+			"version": "1.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/got/node_modules/lowercase-keys": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/got/node_modules/timed-out": {
+			"version": "4.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/got/node_modules/unzip-response": {
+			"version": "2.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/got/node_modules/url-parse-lax": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"prepend-http": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/got/node_modules/url-parse-lax/node_modules/prepend-http": {
+			"version": "1.0.4",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-auth-token": {
+			"version": "3.3.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"rc": "^1.1.6",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-auth-token/node_modules/rc": {
+			"version": "1.2.1",
+			"inBundle": true,
+			"license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+			"dependencies": {
+				"deep-extend": "~0.4.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
+			},
+			"bin": {
+				"rc": "index.js"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-auth-token/node_modules/rc/node_modules/deep-extend": {
+			"version": "0.4.2",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"iojs": ">=1.0.0",
+				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-auth-token/node_modules/rc/node_modules/minimist": {
+			"version": "1.2.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-auth-token/node_modules/rc/node_modules/strip-json-comments": {
+			"version": "2.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-url": {
+			"version": "3.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"rc": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-url/node_modules/rc": {
+			"version": "1.2.1",
+			"inBundle": true,
+			"license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+			"dependencies": {
+				"deep-extend": "~0.4.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
+			},
+			"bin": {
+				"rc": "index.js"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-url/node_modules/rc/node_modules/deep-extend": {
+			"version": "0.4.2",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"iojs": ">=1.0.0",
+				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-url/node_modules/rc/node_modules/minimist": {
+			"version": "1.2.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-url/node_modules/rc/node_modules/strip-json-comments": {
+			"version": "2.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/semver-diff": {
+			"version": "2.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^5.0.3"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/xdg-basedir": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/uuid": {
+			"version": "3.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"bin": {
+				"uuid": "bin/uuid"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/validate-npm-package-license": {
+			"version": "3.0.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"spdx-correct": "~1.0.0",
+				"spdx-expression-parse": "~1.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-correct": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"spdx-license-ids": "^1.0.2"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-correct/node_modules/spdx-license-ids": {
+			"version": "1.2.2",
+			"inBundle": true,
+			"license": "Unlicense"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
+			"version": "1.0.4",
+			"inBundle": true,
+			"license": "(MIT AND CC-BY-3.0)"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/validate-npm-package-name": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"builtins": "^1.0.3"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/validate-npm-package-name/node_modules/builtins": {
+			"version": "1.0.3",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/which": {
+			"version": "1.2.14",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"which": "bin/which"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/which/node_modules/isexe": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/worker-farm": {
+			"version": "1.3.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"errno": ">=0.1.1 <0.2.0-0",
+				"xtend": ">=4.0.0 <4.1.0-0"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/worker-farm/node_modules/errno": {
+			"version": "0.1.4",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"prr": "~0.0.0"
+			},
+			"bin": {
+				"errno": "cli.js"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/worker-farm/node_modules/errno/node_modules/prr": {
+			"version": "0.0.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/worker-farm/node_modules/xtend": {
+			"version": "4.0.1",
+			"inBundle": true,
+			"engines": {
+				"node": ">=0.4"
+			}
+		},
+		"node_modules/npx/node_modules/npm/node_modules/wrappy": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/npm/node_modules/write-file-atomic": {
+			"version": "2.1.0",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"slide": "^1.1.5"
+			}
+		},
+		"node_modules/npx/node_modules/number-is-nan": {
+			"version": "1.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/once": {
+			"version": "1.4.0",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/npx/node_modules/os-homedir": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/os-locale": {
+			"version": "3.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"execa": "^1.0.0",
+				"lcid": "^2.0.0",
+				"mem": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/npx/node_modules/os-locale/node_modules/cross-spawn": {
+			"version": "6.0.5",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"nice-try": "^1.0.4",
+				"path-key": "^2.0.1",
+				"semver": "^5.5.0",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
+			},
+			"engines": {
+				"node": ">=4.8"
+			}
+		},
+		"node_modules/npx/node_modules/os-locale/node_modules/execa": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"cross-spawn": "^6.0.0",
+				"get-stream": "^4.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/npx/node_modules/os-locale/node_modules/get-stream": {
+			"version": "4.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"pump": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/npx/node_modules/os-tmpdir": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/osenv": {
+			"version": "0.1.5",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"os-homedir": "^1.0.0",
+				"os-tmpdir": "^1.0.0"
+			}
+		},
+		"node_modules/npx/node_modules/p-defer": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/p-finally": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/p-is-promise": {
+			"version": "2.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/npx/node_modules/p-limit": {
+			"version": "1.3.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-try": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/p-locate": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/p-try": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/package-json": {
+			"version": "4.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"got": "^6.7.1",
+				"registry-auth-token": "^3.0.1",
+				"registry-url": "^3.0.3",
+				"semver": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/path-exists": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/path-is-absolute": {
+			"version": "1.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/path-is-inside": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "(WTFPL OR MIT)"
+		},
+		"node_modules/npx/node_modules/path-key": {
+			"version": "2.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/pify": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/prepend-http": {
+			"version": "1.0.4",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/pseudomap": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/pump": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"node_modules/npx/node_modules/rc": {
+			"version": "1.2.8",
+			"inBundle": true,
+			"license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+			"dependencies": {
+				"deep-extend": "^0.6.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
+			},
+			"bin": {
+				"rc": "cli.js"
+			}
+		},
+		"node_modules/npx/node_modules/registry-auth-token": {
+			"version": "3.4.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"rc": "^1.1.6",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/npx/node_modules/registry-url": {
+			"version": "3.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"rc": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/require-directory": {
+			"version": "2.1.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/require-main-filename": {
+			"version": "1.0.1",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/rimraf": {
+			"version": "2.7.1",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			}
+		},
+		"node_modules/npx/node_modules/safe-buffer": {
+			"version": "5.2.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npx/node_modules/semver": {
+			"version": "5.7.1",
+			"inBundle": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver"
+			}
+		},
+		"node_modules/npx/node_modules/semver-diff": {
+			"version": "2.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^5.0.3"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/set-blocking": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/shebang-command": {
+			"version": "1.2.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/shebang-regex": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/signal-exit": {
+			"version": "3.0.2",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/string-width": {
+			"version": "2.1.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/strip-ansi": {
+			"version": "4.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/strip-eof": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/strip-json-comments": {
+			"version": "2.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/supports-color": {
+			"version": "5.5.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/term-size": {
+			"version": "1.2.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"execa": "^0.7.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/timed-out": {
+			"version": "4.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/unique-string": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"crypto-random-string": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/unzip-response": {
+			"version": "2.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/update-notifier": {
+			"version": "2.5.0",
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"boxen": "^1.2.1",
+				"chalk": "^2.0.1",
+				"configstore": "^3.0.0",
+				"import-lazy": "^2.1.0",
+				"is-ci": "^1.0.10",
+				"is-installed-globally": "^0.1.0",
+				"is-npm": "^1.0.0",
+				"latest-version": "^3.0.0",
+				"semver-diff": "^2.0.0",
+				"xdg-basedir": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/url-parse-lax": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"prepend-http": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/validate-npm-package-name": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"builtins": "^1.0.3"
+			}
+		},
+		"node_modules/npx/node_modules/which": {
+			"version": "1.3.1",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"which": "bin/which"
+			}
+		},
+		"node_modules/npx/node_modules/which-module": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/widest-line": {
+			"version": "2.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"string-width": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/wrap-ansi": {
+			"version": "2.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/wrap-ansi/node_modules/ansi-regex": {
+			"version": "2.1.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"number-is-nan": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/wrap-ansi/node_modules/string-width": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"code-point-at": "^1.0.0",
+				"is-fullwidth-code-point": "^1.0.0",
+				"strip-ansi": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/wrap-ansi/node_modules/strip-ansi": {
+			"version": "3.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npx/node_modules/wrappy": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/write-file-atomic": {
+			"version": "2.4.3",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"node_modules/npx/node_modules/xdg-basedir": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npx/node_modules/y18n": {
+			"version": "4.0.0",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/yallist": {
+			"version": "2.1.2",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npx/node_modules/yargs": {
+			"version": "11.1.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^4.0.0",
+				"decamelize": "^1.1.1",
+				"find-up": "^2.1.0",
+				"get-caller-file": "^1.0.1",
+				"os-locale": "^3.1.0",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^1.0.1",
+				"set-blocking": "^2.0.0",
+				"string-width": "^2.0.0",
+				"which-module": "^2.0.0",
+				"y18n": "^3.2.1",
+				"yargs-parser": "^9.0.2"
+			}
+		},
+		"node_modules/npx/node_modules/yargs-parser": {
+			"version": "9.0.2",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"camelcase": "^4.1.0"
+			}
+		},
+		"node_modules/npx/node_modules/yargs/node_modules/y18n": {
+			"version": "3.2.1",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/obsidian": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.7.2.tgz",
+			"integrity": "sha512-k9hN9brdknJC+afKr5FQzDRuEFGDKbDjfCazJwpgibwCAoZNYHYV8p/s3mM8I6AsnKrPKNXf8xGuMZ4enWelZQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/codemirror": "5.60.8",
+				"moment": "2.29.4"
+			},
+			"peerDependencies": {
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.0.0"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/optionator": {
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+			"integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"deep-is": "^0.1.3",
+				"fast-levenshtein": "^2.0.6",
+				"levn": "^0.4.1",
+				"prelude-ls": "^1.2.1",
+				"type-check": "^0.4.0",
+				"word-wrap": "^1.2.5"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/parent-module": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"callsites": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-type": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/prelude-ls": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/punycode": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/queue-microtask": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/regexpp": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			}
+		},
+		"node_modules/resolve-from": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/reusify": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"iojs": ">=1.0.0",
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"deprecated": "Rimraf versions prior to v4 are no longer supported",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/run-parallel": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"queue-microtask": "^1.2.2"
+			}
+		},
+		"node_modules/semver": {
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/slash": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-json-comments": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/style-mod": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
+			"integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/text-table": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/to-regex-range": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-number": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=8.0"
+			}
+		},
+		"node_modules/ts-api-utils": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
+			"integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.2.0"
+			}
+		},
+		"node_modules/tslib": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+			"dev": true,
+			"license": "0BSD"
+		},
+		"node_modules/tsutils": {
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+			"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^1.8.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			},
+			"peerDependencies": {
+				"typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+			}
+		},
+		"node_modules/tsutils/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"dev": true,
+			"license": "0BSD"
+		},
+		"node_modules/type-check": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"prelude-ls": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/type-fest": {
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "4.7.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		},
+		"node_modules/typescript-eslint": {
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.7.0.tgz",
+			"integrity": "sha512-nEHbEYJyHwsuf7c3V3RS7Saq+1+la3i0ieR3qP0yjqWSzVmh8Drp47uOl9LjbPANac4S7EFSqvcYIKXUUwIfIQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/eslint-plugin": "8.7.0",
+				"@typescript-eslint/parser": "8.7.0",
+				"@typescript-eslint/utils": "8.7.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin": {
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.7.0.tgz",
+			"integrity": "sha512-RIHOoznhA3CCfSTFiB6kBGLQtB/sox+pJ6jeFu6FxJvqL8qRxq/FfGO/UhsGgQM9oGdXkV4xUgli+dt26biB6A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/regexpp": "^4.10.0",
+				"@typescript-eslint/scope-manager": "8.7.0",
+				"@typescript-eslint/type-utils": "8.7.0",
+				"@typescript-eslint/utils": "8.7.0",
+				"@typescript-eslint/visitor-keys": "8.7.0",
+				"graphemer": "^1.4.0",
+				"ignore": "^5.3.1",
+				"natural-compare": "^1.4.0",
+				"ts-api-utils": "^1.3.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+				"eslint": "^8.57.0 || ^9.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/parser": {
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.7.0.tgz",
+			"integrity": "sha512-lN0btVpj2unxHlNYLI//BQ7nzbMJYBVQX5+pbNXvGYazdlgYonMn4AhhHifQ+J4fGRYA/m1DjaQjx+fDetqBOQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"@typescript-eslint/scope-manager": "8.7.0",
+				"@typescript-eslint/types": "8.7.0",
+				"@typescript-eslint/typescript-estree": "8.7.0",
+				"@typescript-eslint/visitor-keys": "8.7.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/scope-manager": {
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.7.0.tgz",
+			"integrity": "sha512-87rC0k3ZlDOuz82zzXRtQ7Akv3GKhHs0ti4YcbAJtaomllXoSO8hi7Ix3ccEvCd824dy9aIX+j3d2UMAfCtVpg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.7.0",
+				"@typescript-eslint/visitor-keys": "8.7.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/type-utils": {
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.7.0.tgz",
+			"integrity": "sha512-tl0N0Mj3hMSkEYhLkjREp54OSb/FI6qyCzfiiclvJvOqre6hsZTGSnHtmFLDU8TIM62G7ygEa1bI08lcuRwEnQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/typescript-estree": "8.7.0",
+				"@typescript-eslint/utils": "8.7.0",
+				"debug": "^4.3.4",
+				"ts-api-utils": "^1.3.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/types": {
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.7.0.tgz",
+			"integrity": "sha512-LLt4BLHFwSfASHSF2K29SZ+ZCsbQOM+LuarPjRUuHm+Qd09hSe3GCeaQbcCr+Mik+0QFRmep/FyZBO6fJ64U3w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.7.0.tgz",
+			"integrity": "sha512-MC8nmcGHsmfAKxwnluTQpNqceniT8SteVwd2voYlmiSWGOtjvGXdPl17dYu2797GVscK30Z04WRM28CrKS9WOg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"@typescript-eslint/types": "8.7.0",
+				"@typescript-eslint/visitor-keys": "8.7.0",
+				"debug": "^4.3.4",
+				"fast-glob": "^3.3.2",
+				"is-glob": "^4.0.3",
+				"minimatch": "^9.0.4",
+				"semver": "^7.6.0",
+				"ts-api-utils": "^1.3.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/utils": {
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.7.0.tgz",
+			"integrity": "sha512-ZbdUdwsl2X/s3CiyAu3gOlfQzpbuG3nTWKPoIvAu1pu5r8viiJvv2NPN2AqArL35NCYtw/lrPPfM4gxrMLNLPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@typescript-eslint/scope-manager": "8.7.0",
+				"@typescript-eslint/types": "8.7.0",
+				"@typescript-eslint/typescript-estree": "8.7.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.7.0.tgz",
+			"integrity": "sha512-b1tx0orFCCh/THWPQa2ZwWzvOeyzzp36vkJYOpVg0u8UVOIsfVrnuC9FqAw9gRKn+rG2VmWQ/zDJZzkxUnj/XQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.7.0",
+				"eslint-visitor-keys": "^3.4.3"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/uri-js": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/w3c-keyname": {
+			"version": "2.2.8",
+			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/word-wrap": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -12,13 +12,20 @@
 	"author": "",
 	"license": "MIT",
 	"devDependencies": {
+		"@eslint/js": "^9.11.1",
 		"@types/node": "^16.11.6",
 		"@typescript-eslint/eslint-plugin": "5.29.0",
 		"@typescript-eslint/parser": "5.29.0",
 		"builtin-modules": "3.3.0",
 		"esbuild": "0.17.3",
+		"eslint": "^8.57.1",
+		"globals": "^15.9.0",
 		"obsidian": "latest",
 		"tslib": "2.4.0",
-		"typescript": "4.7.4"
+		"typescript": "4.7.4",
+		"typescript-eslint": "^8.7.0"
+	},
+	"dependencies": {
+		"npx": "^10.2.2"
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -70,7 +70,7 @@ export default class TesseractOcrPlugin extends Plugin {
 						let newContent = content;
 						// Search for ![[]] links in content that don't have details
 						let matches = fileImages
-							.filter((fi) => newContent.match(new RegExp(`${fi.embed.original}(?!<details>)`, "g")))
+							.filter((fi) => newContent.match(new RegExp(`${this.escapeRegExp(fi.embed.original)}(?!<details>)`, "g")))
 							.map((fi):ImageLink => { return {match: fi.embed.link, path: fi.file ? fi.file.path: ""} });
 
 						if(matches.length !== 0) console.log('found ' + matches.length + ' images without details in file ' + file.name + ' processing...');
@@ -119,6 +119,11 @@ export default class TesseractOcrPlugin extends Plugin {
 
 	async saveSettings() {
 		await this.saveData(this.settings);
+	}
+
+	private escapeRegExp(regexstring: string) {
+		// from MDN https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions#escaping
+  		return regexstring.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
 	}
 
 	private getAllFiles(): TFile[] {

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,7 +71,7 @@ export default class TesseractOcrPlugin extends Plugin {
 						// Search for ![[]] links in content that don't have details
 						let matches = fileImages
 							.filter((fi) => newContent.match(new RegExp(`${this.escapeRegExp(fi.embed.original)}(?!<details>)`, "g")))
-							.map((fi):ImageLink => { return {match: fi.embed.link, path: fi.file ? fi.file.path: ""} });
+							.map((fi):ImageLink => { return {match: fi.embed.original, path: fi.file ? fi.file.path: ""} });
 
 						if(matches.length !== 0) console.log('found ' + matches.length + ' images without details in file ' + file.name + ' processing...');
 						let errorCounter = 0;


### PR DESCRIPTION
The regex code was not properly matching links with special characters in them. This was causing the path to be a truncated part of the image filename. When this truncated path matched an existing image file, that file would have OCR text inserted into the file. This caused lots of files to have the same (wrong) OCR text.

I changed the way the images were identified to pull from each file's embeds list. No need to use regex to find them. This lets you use the API to locate the file path matching that name using Obsidian's own logic for resolving the file name. There's no need to have an image path parameter and use that to know what is/is not an image. That was a rigid design that didn't work for many configurations of Obsidian and resulted in many images never getting OCR text due to their location.

Once we had a list of the embeds, this allows for directly finding the location of that link in the file using the exact link text. And associating the embed with its corresponding TFile object, we can get its path without re-creating it (incorrectly). This resolves the original bug.